### PR TITLE
Support for Webpack 2.2.1

### DIFF
--- a/chunk-webpack-plugin.js
+++ b/chunk-webpack-plugin.js
@@ -39,7 +39,7 @@ function ChunkWebpackPlugin(options) {
 		throw new Error('The name of the target ("to") chunk cannot also be in the "from" chunk name list.');
 	}
 
-	base.call(this, this.targetChunkName, this.targetChunkName + '.js');
+	base.call(this, { name: this.targetChunkName, filename: this.targetChunkName + '.js' });
 }
 
 ChunkWebpackPlugin.prototype = Object.create(base.prototype);

--- a/chunk-webpack-plugin.js
+++ b/chunk-webpack-plugin.js
@@ -1,92 +1,88 @@
 'use strict';
 
-var CommonsChunkPlugin = require('webpack').optimize.CommonsChunkPlugin;
-var util = require('./lib/util');
-var Tools = require('./lib/Tools');
+const CommonsChunkPlugin = require('webpack').optimize.CommonsChunkPlugin;
+const util = require('./lib/util');
+const Tools = require('./lib/Tools');
 
-var base = CommonsChunkPlugin;
+class ChunkWebpackPlugin extends CommonsChunkPlugin {
+  constructor(options) {
+    if (typeof options !== 'object')
+      throw new TypeError('Argument `options` must be an object.');
+    if (options.from && !util.typeOrArrayOf(options.from, 'string'))
+      throw new Error('Option `from` must be either a string or an array of strings');
+    if (!util.checkType(options.to, 'string'))
+      throw new Error('Option `to` must be a string.');
+    if (!util.typeOrArrayOf(options.test, RegExp) && !util.checkType(options.test, 'function'))
+      throw new Error('Option `test` must be either a funtion, RegExp or an array of RegExp`s.');
 
-function ChunkWebpackPlugin(options) {
-	if (!(this instanceof ChunkWebpackPlugin))
-		throw new Error('Function `ChunkWebpackPlugin` is a constructor and must be instantiated with the `new` keyword.');
-	if (typeof options !== 'object')
-		throw new TypeError('Argument `options` must be an object.');
-	if (options.from && !util.typeOrArrayOf(options.from, 'string'))
-		throw new Error('Option `from` must be either a string or an array of strings');
-	if (!util.checkType(options.to, 'string'))
-		throw new Error('Option `to` must be a string.');
-	if (!util.typeOrArrayOf(options.test, RegExp) && !util.checkType(options.test, 'function'))
-		throw new Error('Option `test` must be either a funtion, RegExp or an array of RegExp`s.');
+    const targetChunkName = options.to;
+    let fromChunkNameList = null;
+    let testers;
 
-	this.targetChunkName = options.to;
-	if( Array.isArray(options.from) ) {
-		this.fromChunkNameList = options.from
-	} else if( typeof options.from === 'string' ) {
-		this.fromChunkNameList = [options.from]
-	} else {
-		this.fromChunkNameList = null
-	}
-	if( Array.isArray(options.test) ) {
-		this.testers = options.test
-	} else if( typeof options.test === 'function' ) {
-		this.testers = options.test
-	} else {
-		this.testers = [options.test]
-	}
+    if (Array.isArray(options.from)) {
+      fromChunkNameList = options.from
+    } else if (typeof options.from === 'string') {
+      fromChunkNameList = [options.from]
+    }
 
-	if (this.fromChunkNameList && this.fromChunkNameList.indexOf(this.targetChunkName) !== -1) {
-		// yeah, if this happened something is wrong
-		throw new Error('The name of the target ("to") chunk cannot also be in the "from" chunk name list.');
-	}
+    if (Array.isArray(options.test)) {
+      testers = options.test
+    } else if (typeof options.test === 'function') {
+      testers = options.test
+    } else {
+      testers = [options.test]
+    }
 
-	base.call(this, { name: this.targetChunkName, filename: this.targetChunkName + '.js' });
+
+    if (fromChunkNameList && fromChunkNameList.indexOf(targetChunkName) !== -1) {
+      // yeah, if this happened something is wrong
+      throw new Error('The name of the target ("to") chunk cannot also be in the "from" chunk name list.');
+    }
+
+    super({ name: targetChunkName });
+    this.targetChunkName = targetChunkName;
+    this.fromChunkNameList = fromChunkNameList;
+    this.testers = testers;
+  }
+
+  apply(compiler) {
+    const self = this; // i lost my lambdas ;_;
+
+    compiler.plugin('compilation', function (compilation) {
+      const tools = new Tools(compilation);
+
+      compilation.plugin('optimize-chunks', function (chunkList) {
+        if (tools.compilationOptimized)
+          return;
+        tools.compilationOptimized = true;
+
+        // 1. find the target chunk (and ensure it exists) before we take anything from other chunks
+        let targetChunk = tools.findExistingChunk(chunkList, self.targetChunkName);
+        if (!targetChunk) {
+          // Create a new child chunk
+          targetChunk = tools.createChildChunk(this, self.targetChunkName, chunkList)
+        }
+        if (!targetChunk) {
+          // Fatality!
+          throw new Error('Target (to) chunk "' + self.targetChunkName + '" wasn\'t found.');
+        }
+
+        // 2. filter out chunks we shouldn't be touching
+        if (self.fromChunkNameList) {
+          chunkList = chunkList.filter(function (chunk) {
+            return self.fromChunkNameList.indexOf(chunk.name) !== -1;
+          });
+        }
+
+        // 3. take all the modules that pass any of our test regex
+        const takenModules = tools.takeMatchingModules(chunkList, self.testers);
+
+        // 4. insert all taken modules into our target chunk
+        tools.insertModulesIntoChunk(targetChunk, takenModules);
+      });
+    });
+    super.apply.apply(this, arguments);
+  }
 }
-
-ChunkWebpackPlugin.prototype = Object.create(base.prototype);
-
-function apply(compiler) {
-	var self = this; // i lost my lambdas ;_;
-
-	compiler.plugin('compilation', function (compilation) {
-		var tools = new Tools(compilation)
-
-		compilation.plugin('optimize-chunks', function (chunkList) {
-			if( tools.compilationOptimized )
-				return;
-			tools.compilationOptimized = true
-
-			// 1. find the target chunk (and ensure it exists) before we take anything from other chunks
-			var targetChunk = tools.findExistingChunk(chunkList, self.targetChunkName);
-			if (!targetChunk) {
-				// Create a new child chunk
-				targetChunk = tools.createChildChunk(this, self.targetChunkName, chunkList)
-			}
-			if (!targetChunk) {
-				// Fatality!
-				throw new Error('Target (to) chunk "' + self.targetChunkName + '" wasn\'t found.');
-			}
-
-			// 2. filter out chunks we shouldn't be touching
-			if( self.fromChunkNameList ) {
-				chunkList = chunkList.filter(function (chunk) {
-					return self.fromChunkNameList.indexOf(chunk.name) !== -1;
-				});
-			}
-
-			// 3. take all the modules that pass any of our test regex
-			var takenModules = tools.takeMatchingModules(chunkList, self.testers);
-
-			// 4. insert all taken modules into our target chunk
-			tools.insertModulesIntoChunk(targetChunk, takenModules);
-		});
-	});
-
-	base.prototype.apply.apply(this, arguments);
-}
-
-Object.defineProperty(ChunkWebpackPlugin.prototype, 'apply', {
-	value: apply,
-	enumerable: false
-});
 
 module.exports = ChunkWebpackPlugin;

--- a/lib/Tools.js
+++ b/lib/Tools.js
@@ -56,7 +56,7 @@ function findExistingChunk(chunkList, targetChunkName) {
 }
 function findEntryChunk(chunkList) {
 	for (var i = 0; i < chunkList.length; i++) {
-		if (chunkList[i].entry) {
+		if (chunkList[i].hasRuntime()) {
 			return chunkList[i];
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   ],
   "license": "ISC",
   "devDependencies": {
-    "webpack": "^1.14.0"
+    "webpack": "^2.2.0"
   },
   "keywords": [
     "webpack",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   ],
   "license": "ISC",
   "devDependencies": {
-    "webpack": "^2.2.0"
+    "webpack": "^2.2.1"
   },
   "keywords": [
     "webpack",


### PR DESCRIPTION
Cause #1 does not work anymore with webpack 2.2.1 I made some changes based on the work of @laggingreflex to make this working again.

PR #1 throws the following error with webpack 2.2.1 due to a refactoring to ES6 classes (compare [2.2.1](https://github.com/webpack/webpack/blob/v2.2.1/lib/optimize/CommonsChunkPlugin.js) vs. [2.2.0](https://github.com/webpack/webpack/blob/v2.2.0/lib/optimize/CommonsChunkPlugin.js))


```
	base.call(this, { name: this.targetChunkName, filename: this.targetChunkName + '.js' });
	     ^

TypeError: Class constructor CommonsChunkPlugin cannot be invoked without 'new'
```
@nezed I removed  also the `filename` override.