### PR TITLE
Set webpack minChunks to Infinity

### DIFF
--- a/chunk-webpack-plugin.js
+++ b/chunk-webpack-plugin.js
@@ -42,6 +42,7 @@ class ChunkWebpackPlugin extends CommonsChunkPlugin {
     super({ name: targetChunkName });
     this.targetChunkName = targetChunkName;
     this.fromChunkNameList = fromChunkNameList;
+    this.minChunks = Infinity;
     this.testers = testers;
   }
 


### PR DESCRIPTION
Not sure why, but if minChunks isn't set to Infinity, I was seeing some of my application code going into the vendor bundle. Unsure if this is the right solution, but it is working for me. Made this a PR since there's no issue tracker enabled in the repo.